### PR TITLE
Configure CORS for specific origin and credentials

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,7 +5,10 @@ const authMiddleware = require("./middlewares/authMiddleware");
 
 const app = express();
 
-app.use(cors());
+app.use(cors({
+  origin: "http://localhost:5173", 
+  credentials: true
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
CORS middleware is now set to allow requests from http://localhost:5173 and support credentials. This improves security and enables cross-origin authentication for the frontend.