### PR TITLE
Add chip rendering to Roulette-Board cells ,merge admin-dashboard into main

### DIFF
--- a/frontend/src/pages/RouletteBoard.jsx
+++ b/frontend/src/pages/RouletteBoard.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
+// bets: { [cellId: string]: denomination }
+const RouletteBoard = ({ bets = {}, onCellClick = () => {}, onCellDrop = () => {} }) => {
   const numbers = [
     { num: 0, color: "green" },
     { num: 32, color: "red" },
@@ -50,6 +51,73 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
     return mainNumbers.find((n) => n.num === num);
   };
 
+  // Helper to render a styled chip on a cell (matches ChipSelector)
+  const colorByDenom = (value) => {
+    switch (value) {
+      case 10:
+        return "#9CA3AF"; // gray
+      case 20:
+        return "#16A34A"; // green
+      case 50:
+        return "#F59E0B"; // amber/orange
+      case 100:
+        return "#F97316"; // orange
+      case 500:
+        return "#EF4444"; // red
+      case 2500:
+        return "#22C55E"; // green
+      default:
+        return "#9CA3AF";
+    }
+  };
+
+  const renderChip = (cellId) => {
+    const denomination = bets[cellId];
+    if (!denomination) return null;
+    return (
+      <div
+        className="absolute left-1/2 top-2/3 -translate-x-1/2 -translate-y-2/3 w-8.5 h-8.5 rounded-full grid place-items-center justify-items-center text-[7px] font-bold cursor-pointer select-none shadow"
+        style={{
+          background: colorByDenom(denomination),
+          color: "#111827",
+          boxShadow:
+            "inset 0 2px 6px rgba(0,0,0,0.25), 0 4px 10px rgba(0,0,0,0.3)",
+          zIndex: 2,
+        }}
+      >
+        {/* stripes ring */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 rounded-full"
+          style={{
+            background:
+              "repeating-conic-gradient(#ffffff 0 8deg, transparent 8deg 28deg)",
+            WebkitMask:
+              "radial-gradient(circle at center, transparent 0 60%, black 61% 100%)",
+            mask:
+              "radial-gradient(circle at center, transparent 0 60%, black 61% 100%)",
+            opacity: 0.9,
+          }}
+        />
+        {/* center */}
+        <span
+          className="pointer-events-none rounded-full grid place-items-center"
+          style={{
+            width: 32,
+            height: 32,
+            background:
+              "radial-gradient(circle at 30% 30%, #f8fafc 0%, #e5e7eb 65%, #d1d5db 100%)",
+            border: "1px solid rgba(0,0,0,0.08)",
+          }}
+        >
+          ₹{denomination}
+        </span>
+        {/* outer rim */}
+        <span className="pointer-events-none absolute inset-0 rounded-full border border-white/30" />
+      </div>
+    );
+  };
+
   const getNumberColor = (color) => {
     if (color === "red") return "bg-[#EC4326] text-white";
     if (color === "black") return "bg-[#0E0E0E] text-white";
@@ -95,6 +163,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
         w-full h-full flex items-center justify-center 
         text-4xl font-bold 
         [clip-path:polygon(20%_0%,80%_0%,100%_0%,100%_100%,20%_100%,0%_50%)]
+        relative
       `}
                   onClick={() => onCellClick("0")}
                   onDragOver={(e) => e.preventDefault()}
@@ -107,6 +176,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                   }}
                 >
                   0
+                  {renderChip("0")}
                 </div>
               </div>
             </div>
@@ -121,9 +191,9 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                     return (
                       <div
                         key={`${row}-${col}`}
-                        className={`${getNumberColor(
-                          numberData?.color
-                        )} w-9 h-12 flex items-center justify-center text-lg font-bold border border-white cursor-pointer`}
+                        className={
+                          `${getNumberColor(numberData?.color)} w-9 h-12 flex items-center justify-center text-lg font-bold border border-white cursor-pointer relative`
+                        }
                         onClick={() =>
                           numberData && onCellClick(String(numberData.num))
                         }
@@ -139,6 +209,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                         }}
                       >
                         {numberData?.num}
+                        {numberData && renderChip(String(numberData.num))}
                       </div>
                     );
                   })
@@ -148,7 +219,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
               {/* Bottom betting sections */}
               <div className="grid grid-cols-12  bg-[#2939A5]">
                 <div
-                  className="col-span-4 text-white text-xs font-bold h-14 flex items-center justify-center border border-white cursor-pointer"
+                  className="col-span-4 text-white text-xs font-bold h-14 flex items-center justify-center border border-white cursor-pointer relative"
                   onClick={() => onCellClick("1st12")}
                   onDragOver={(e) => e.preventDefault()}
                   onDrop={(e) => {
@@ -160,9 +231,10 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                   }}
                 >
                   1ST 12
+                  {renderChip("1st12")}
                 </div>
                 <div
-                  className="col-span-4 text-white text-xs font-bold h-14 flex items-center justify-center border border-white cursor-pointer"
+                  className="col-span-4 text-white text-xs font-bold h-14 flex items-center justify-center border border-white cursor-pointer relative"
                   onClick={() => onCellClick("2nd12")}
                   onDragOver={(e) => e.preventDefault()}
                   onDrop={(e) => {
@@ -174,9 +246,10 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                   }}
                 >
                   2ND 12
+                  {renderChip("2nd12")}
                 </div>
                 <div
-                  className="col-span-4 text-white text-xs font-bold h-14 flex items-center justify-center border border-white cursor-pointer"
+                  className="col-span-4 text-white text-xs font-bold h-14 flex items-center justify-center border border-white cursor-pointer relative"
                   onClick={() => onCellClick("3rd12")}
                   onDragOver={(e) => e.preventDefault()}
                   onDrop={(e) => {
@@ -188,6 +261,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                   }}
                 >
                   3RD 12
+                  {renderChip("3rd12")}
                 </div>
               </div>
             </div>
@@ -207,6 +281,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                 }}
               >
                 2 TO 1
+               
               </div>
               <div
                 className="bg-[#2939A5] text-white text-lg font-bold h-12 flex items-center justify-center border border-white cursor-pointer"
@@ -221,6 +296,7 @@ const RouletteBoard = ({ onCellClick = () => {}, onCellDrop = () => {} }) => {
                 }}
               >
                 2 TO 1
+                
               </div>
               <div
                 className="bg-[#2939A5] text-white text-lg font-bold h-12 flex items-center justify-center border border-white cursor-pointer"


### PR DESCRIPTION
Introduces a 'bets' prop to RouletteBoard and renders styled chips on cells with active bets. Chips visually represent the denomination and are displayed on number and section cells, enhancing the board's interactivity and clarity.