### PR TITLE
Pass bets prop to RouletteBoard component

### DIFF
--- a/frontend/src/pages/AutoRoulette.jsx
+++ b/frontend/src/pages/AutoRoulette.jsx
@@ -71,7 +71,11 @@ const AutoRoulette = () => {
 
       {/* Board below */}
       <div className="w-full z-10">
-        <RouletteBoard onCellClick={handleCellClick} onCellDrop={handleCellDrop} />
+        <RouletteBoard
+          bets={Object.fromEntries(bets.map(b => [b.position, b.amount]))}
+          onCellClick={handleCellClick}
+          onCellDrop={handleCellDrop}
+        />
       </div>
 
       {/* Optional: show current total in the corner */}


### PR DESCRIPTION
Added the 'bets' prop to the RouletteBoard component, mapping bet positions to their amounts. This allows the board to display current bets based on the state.